### PR TITLE
Update git version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ depends 'lvm', '~> 1.1.0'
 depends 'rightscale_volume', '~> 1.1.0'
 depends 'rightscale_backup', '~> 1.1.1'
 depends 'dns', '~> 0.1.3'
-depends 'git', '~> 2.8.4'
+depends 'git', '~> 2.7.0'
 
 recipe 'rs-mysql::default', 'Sets up a standalone MySQL server'
 recipe 'rs-mysql::collectd', 'Sets up collectd monitoring for MySQL server'


### PR DESCRIPTION
Change to mysql cookbook to pull in git cookbook version 2.7.0 which makes it consistent with the other cookbooks. Also helps avoid dependency issues.
