### PR TITLE
Ps permission auto.cnf fix

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -119,9 +119,7 @@ mysql_database 'application database' do
   connection mysql_connection_info
   database_name node['rs-mysql']['application_database_name']
   action :create
-  not_if do
-    Dir.exists?("#{node['mysql']['data_dir']}/#{node['rs-mysql']['application_database_name']}") 
-  end
+  not_if { node['rs-mysql']['application_database_name'].to_s.empty? }
 end
 
 if !node['rs-mysql']['application_username'].to_s.empty? && !node['rs-mysql']['application_password'].to_s.empty?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -119,7 +119,9 @@ mysql_database 'application database' do
   connection mysql_connection_info
   database_name node['rs-mysql']['application_database_name']
   action :create
-  not_if { node['rs-mysql']['application_database_name'].to_s.empty? }
+  not_if do
+    Dir.exists?("#{node['mysql']['data_dir']}/#{node['rs-mysql']['application_database_name']}") 
+  end
 end
 
 if !node['rs-mysql']['application_username'].to_s.empty? && !node['rs-mysql']['application_password'].to_s.empty?

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -112,9 +112,9 @@ if mysql_master_info && mysql_master_info.has_key?(:file) && mysql_master_info.h
 end
 
 #remove auto.conf if exists in backup. causes isssues with same UUIDs
-file "#{node['rs-mysql']['device']['mount_point']}/auto.conf" do
+file "#{node['rs-mysql']['device']['mount_point']}/mysql/auto.cnf" do
   action :delete
-  only_if do ::File.exists?("#{node['rs-mysql']['device']['mount_point']}/auto.conf") end
+  only_if do ::File.exists?("#{node['rs-mysql']['device']['mount_point']}/mysql/auto.cnf") end
 end
 
 

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -111,7 +111,7 @@ if mysql_master_info && mysql_master_info.has_key?(:file) && mysql_master_info.h
   change_master << ", MASTER_LOG_FILE='#{mysql_master_info[:file]}', MASTER_LOG_POS=#{mysql_master_info[:position]}"
 end
 
-#remove auto.conf if exists in backup. causes isssues with same UUIDs
+#remove auto.cnf if exists in backup. causes isssues with same UUIDs
 file "#{node['rs-mysql']['device']['mount_point']}/mysql/auto.cnf" do
   action :delete
   only_if do ::File.exists?("#{node['rs-mysql']['device']['mount_point']}/mysql/auto.cnf") end

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -111,6 +111,11 @@ if mysql_master_info && mysql_master_info.has_key?(:file) && mysql_master_info.h
   change_master << ", MASTER_LOG_FILE='#{mysql_master_info[:file]}', MASTER_LOG_POS=#{mysql_master_info[:position]}"
 end
 
+#remove auto.conf if exists in backup. causes isssues with same UUIDs
+file "#{node['rs-mysql']['device']['mount_point']}/auto.conf" do
+  action :delete
+end
+
 mysql_database 'change master host' do
   database_name 'mysql'
   connection mysql_connection_info

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -114,7 +114,9 @@ end
 #remove auto.conf if exists in backup. causes isssues with same UUIDs
 file "#{node['rs-mysql']['device']['mount_point']}/auto.conf" do
   action :delete
+  only_if do ::File.exists?("#{node['rs-mysql']['device']['mount_point']}/auto.conf") end
 end
+
 
 mysql_database 'change master host' do
   database_name 'mysql'

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -111,12 +111,11 @@ if mysql_master_info && mysql_master_info.has_key?(:file) && mysql_master_info.h
   change_master << ", MASTER_LOG_FILE='#{mysql_master_info[:file]}', MASTER_LOG_POS=#{mysql_master_info[:position]}"
 end
 
-#remove auto.cnf if exists in backup. causes isssues with same UUIDs
+# Remove auto.cnf if it exists, included in version 5.6+.  A restored auto.cnf file contains the UUID of the DB that
+# its backup came from, resulting in replication issues.
 file "#{node['rs-mysql']['device']['mount_point']}/mysql/auto.cnf" do
   action :delete
-  only_if do ::File.exists?("#{node['rs-mysql']['device']['mount_point']}/mysql/auto.cnf") end
 end
-
 
 mysql_database 'change master host' do
   database_name 'mysql'

--- a/recipes/stripe.rb
+++ b/recipes/stripe.rb
@@ -31,7 +31,7 @@ detach_timeout = node['rs-mysql']['device']['detach_timeout'].to_i * device_coun
 
 execute "set decommission timeout to #{detach_timeout}" do
   command "rs_config --set decommission_timeout #{detach_timeout}"
-  not_if "[ `rs_config --get decommission_timeout` -eq #{detach_timeout} ]"
+  #not_if "[ `rs_config --get decommission_timeout` -eq #{detach_timeout} ]"
 end
 
 each_device_size = (size.to_f / device_count.to_f).ceil
@@ -121,7 +121,6 @@ end
 # When recovering from a backup uids could have changed.
 execute "change permissions #{new_mysql_dir} owner" do
   command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
-  only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
 end
 
 # Override the mysql data_dir. This will do the following:

--- a/recipes/stripe.rb
+++ b/recipes/stripe.rb
@@ -31,7 +31,7 @@ detach_timeout = node['rs-mysql']['device']['detach_timeout'].to_i * device_coun
 
 execute "set decommission timeout to #{detach_timeout}" do
   command "rs_config --set decommission_timeout #{detach_timeout}"
-  #not_if "[ `rs_config --get decommission_timeout` -eq #{detach_timeout} ]"
+  not_if "[ `rs_config --get decommission_timeout` -eq #{detach_timeout} ]"
 end
 
 each_device_size = (size.to_f / device_count.to_f).ceil
@@ -117,10 +117,11 @@ directory new_mysql_dir do
   action :create
 end
 
-# Make sure that the permissions for the  'mysql' directory are set correctly.
+# Make sure that the permissions for the 'mysql' directory are set correctly.
 # When recovering from a backup uids could have changed.
 execute "change permissions #{new_mysql_dir} owner" do
   command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
+  not_if "stat -c %U #{new_mysql_dir}/mysql |grep mysql"
 end
 
 # Override the mysql data_dir. This will do the following:

--- a/recipes/stripe.rb
+++ b/recipes/stripe.rb
@@ -117,6 +117,15 @@ directory new_mysql_dir do
   action :create
 end
 
+
+# Make sure that the permissions for the  'mysql' directory are set correctly.
+# When recovering from a backup uids could have changed.
+execute "change permissions #{new_mysql_dir} owner" do
+  command "chown -Rf mysql:mysql #{new_mysql_dir}"
+  only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
+end
+
+
 # Override the mysql data_dir. This will do the following:
 #   - Change the data_dir setting in the my.cnf to the new location.
 #   - Move the data from the /var/lib/mysql to this new location. This will be done only if the new location is

--- a/recipes/stripe.rb
+++ b/recipes/stripe.rb
@@ -117,14 +117,12 @@ directory new_mysql_dir do
   action :create
 end
 
-
 # Make sure that the permissions for the  'mysql' directory are set correctly.
 # When recovering from a backup uids could have changed.
 execute "change permissions #{new_mysql_dir} owner" do
-  command "chown -Rf mysql:mysql #{new_mysql_dir}"
+  command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
   only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
 end
-
 
 # Override the mysql data_dir. This will do the following:
 #   - Change the data_dir setting in the my.cnf to the new location.

--- a/recipes/stripe.rb
+++ b/recipes/stripe.rb
@@ -122,6 +122,7 @@ end
 execute "change permissions #{new_mysql_dir} owner" do
   command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
   not_if "stat -c %U #{new_mysql_dir}/mysql |grep mysql"
+  action :run
 end
 
 # Override the mysql data_dir. This will do the following:

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -101,11 +101,12 @@ directory new_mysql_dir do
   action :create
 end
 
-# Make sure that the permissions for the  'mysql' directory are set correctly.
+# Make sure that the permissions for the 'mysql' directory are set correctly.
 # When recovering from a backup uids could have changed.
 execute "change permissions #{new_mysql_dir} owner" do
   command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
-  not_if "stat -c %U #{new_mysql_dir} |grep mysql"
+  not_if "stat -c %U #{new_mysql_dir}/mysql |grep mysql"
+  action :run
 end
 
 # Override the mysql data_dir. This will do the following:

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -103,7 +103,7 @@ end
 # Make sure that the permissions for the  'mysql' directory are set correctly.
 # When recovering from a backup uids could have changed.
 execute "change permissions #{new_mysql_dir} owner" do
-  command "chown -Rf mysql:mysql #{new_mysql_dir}"
+  command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
   only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
 end
 

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -104,7 +104,6 @@ end
 # When recovering from a backup uids could have changed.
 execute "change permissions #{new_mysql_dir} owner" do
   command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
-  only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
 end
 
 # Override the mysql data_dir. This will do the following:

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -94,11 +94,18 @@ else
   end
 end
 
+  directory new_mysql_dir do
+    owner 'mysql'
+    group 'mysql'
+    action :create
+  end
+
+
 # Make sure that there is a 'mysql' directory on the mount point of the volume
-execute "change permissions #{new_mysql_dir} owner" do
-  command "chown -Rf mysql:mysql #{new_mysql_dir}"
-  only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
-end
+  execute "change permissions #{new_mysql_dir} owner" do
+    command "chown -Rf mysql:mysql #{new_mysql_dir}"
+    only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
+  end
 
 
 # Override the mysql data_dir. This will do the following:

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -94,20 +94,18 @@ else
   end
 end
 
-  directory new_mysql_dir do
-    owner 'mysql'
-    group 'mysql'
-    action :create
-  end
+directory new_mysql_dir do
+  owner 'mysql'
+  group 'mysql'
+  action :create
+end
 
-
-  # Make sure that the permissions for the  'mysql' directory are set correctly.
-  # When recovering from a backup uids could have changed.
-  execute "change permissions #{new_mysql_dir} owner" do
-    command "chown -Rf mysql:mysql #{new_mysql_dir}"
-    only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
-  end
-
+# Make sure that the permissions for the  'mysql' directory are set correctly.
+# When recovering from a backup uids could have changed.
+execute "change permissions #{new_mysql_dir} owner" do
+  command "chown -Rf mysql:mysql #{new_mysql_dir}"
+  only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
+end
 
 # Override the mysql data_dir. This will do the following:
 #   - Change the data_dir setting in the my.cnf to the new location.

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -95,11 +95,11 @@ else
 end
 
 # Make sure that there is a 'mysql' directory on the mount point of the volume
-directory new_mysql_dir do
-  owner 'mysql'
-  group 'mysql'
-  action :create
+execute "change permissions #{new_mysql_dir} owner" do
+  command "chown -Rf mysql:mysql #{new_mysql_dir}"
+  only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }
 end
+
 
 # Override the mysql data_dir. This will do the following:
 #   - Change the data_dir setting in the my.cnf to the new location.

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -101,7 +101,8 @@ end
   end
 
 
-# Make sure that there is a 'mysql' directory on the mount point of the volume
+  # Make sure that the permissions for the  'mysql' directory are set correctly.
+  # When recovering from a backup uids could have changed.
   execute "change permissions #{new_mysql_dir} owner" do
     command "chown -Rf mysql:mysql #{new_mysql_dir}"
     only_if { Etc.getpwuid(File.stat(new_mysql_dir).uid).name != "mysql" }

--- a/recipes/volume.rb
+++ b/recipes/volume.rb
@@ -94,6 +94,7 @@ else
   end
 end
 
+# Make sure that there is a 'mysql' directory on the mount point of the volume
 directory new_mysql_dir do
   owner 'mysql'
   group 'mysql'
@@ -104,6 +105,7 @@ end
 # When recovering from a backup uids could have changed.
 execute "change permissions #{new_mysql_dir} owner" do
   command "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
+  not_if "stat -c %U #{new_mysql_dir} |grep mysql"
 end
 
 # Override the mysql data_dir. This will do the following:

--- a/spec/stripe_spec.rb
+++ b/spec/stripe_spec.rb
@@ -16,6 +16,7 @@ describe 'rs-mysql::stripe' do
   let(:nickname) { chef_run.node['rs-mysql']['device']['nickname'] }
   let(:nickname_1) { "#{nickname}_1" }
   let(:nickname_2) { "#{nickname}_2" }
+  let(:new_mysql_dir) {"/mnt/storage/mysql"}
   let(:volume_group) { "#{nickname.gsub('_', '-')}-vg" }
   let(:logical_volume) { "#{nickname.gsub('_', '-')}-lv" }
   let(:detach_timeout) do
@@ -25,6 +26,7 @@ describe 'rs-mysql::stripe' do
   before do
     stub_command('[ `rs_config --get decommission_timeout` -eq 600 ]').and_return(false)
     stub_command("/usr/bin/mysql -u root -e 'show databases;'").and_return(true)
+    stub_command("chown --recursive --silent mysql:mysql #{new_mysql_dir}").and_return(true)
   end
 
   context 'rs-mysql/restore/lineage is not set' do
@@ -32,7 +34,7 @@ describe 'rs-mysql::stripe' do
 
     it 'sets the decommission timeout' do
       expect(chef_run).to run_execute("set decommission timeout to #{detach_timeout * 2}").with(
-        command: "rs_config --set decommission_timeout #{detach_timeout * 2}",
+        command: "rs_config --set decommission_timeout #{detach_timeout * 2}"
       )
     end
 
@@ -65,6 +67,12 @@ describe 'rs-mysql::stripe' do
       expect(chef_run).to create_directory('/mnt/storage/mysql').with(
         owner: 'mysql',
         group: 'mysql',
+      )
+    end
+
+    it 'recursively changes ownership of the mysql directory' do
+      expect(chef_run).to run_execute("change permissions #{new_mysql_dir} owner").with(
+        command: "chown --recursive --silent mysql:mysql #{new_mysql_dir}"
       )
     end
 

--- a/spec/stripe_spec.rb
+++ b/spec/stripe_spec.rb
@@ -34,7 +34,7 @@ describe 'rs-mysql::stripe' do
 
     it 'sets the decommission timeout' do
       expect(chef_run).to run_execute("set decommission timeout to #{detach_timeout * 2}").with(
-        command: "rs_config --set decommission_timeout #{detach_timeout * 2}"
+        command: "rs_config --set decommission_timeout #{detach_timeout * 2}",
       )
     end
 

--- a/spec/stripe_spec.rb
+++ b/spec/stripe_spec.rb
@@ -27,6 +27,7 @@ describe 'rs-mysql::stripe' do
     stub_command('[ `rs_config --get decommission_timeout` -eq 600 ]').and_return(false)
     stub_command("/usr/bin/mysql -u root -e 'show databases;'").and_return(true)
     stub_command("chown --recursive --silent mysql:mysql #{new_mysql_dir}").and_return(true)
+    stub_command("stat -c %U #{new_mysql_dir}/mysql |grep mysql").and_return(false)
   end
 
   context 'rs-mysql/restore/lineage is not set' do

--- a/spec/volume_spec.rb
+++ b/spec/volume_spec.rb
@@ -22,6 +22,7 @@ describe 'rs-mysql::volume' do
     stub_command('[ `rs_config --get decommission_timeout` -eq 300 ]').and_return(false)
     stub_command("/usr/bin/mysql -u root -e 'show databases;'").and_return(true)
     stub_command("chown --recursive --silent mysql:mysql #{new_mysql_dir}").and_return(true)
+    stub_command("stat -c %U #{new_mysql_dir}/mysql |grep mysql").and_return(false)
   end
 
   context 'rs-mysql/restore/lineage is not set' do


### PR DESCRIPTION
Added the code to remove auto.cnf if exists, introduced in mysql 5.6+, causes issues when starting slave because it has the masters uuid information and attempts to use it as its own.  Added recursive mysql ownership of /var/lib/mysql. When recovering from a backup the UID from the system might differ. 
