### PR TITLE
Mysql Startup Check (#1)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,3 +71,5 @@ default['rs-mysql']['import']['dump_file'] = nil
 default['rs-mysql']['collectd']['mysql']['User'] = 'root'
 default['rs-mysql']['collectd']['mysql']['Socket'] = '/var/run/mysqld/mysqld.sock'
 default['rs-mysql']['collectd']['mysql']['Password'] = node['rs-mysql']['server_root_password']
+default['rs-mysql']['startup-timeout'] = 300
+default['mysql']['tunable']['log_error'] = ::File.join(node['mysql']['server']['directories']['slow_log_dir'], 'error.log')

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@rightscale.com'
 license          'Apache 2.0'
 description      'Installs and configures a MySQL server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.4'
+version          '1.2.5'
 
 depends 'chef_handler', '~> 1.1.6'
 depends 'marker', '~> 1.0.1'
@@ -21,6 +21,7 @@ depends 'git', '~> 4.0.2'
 depends 'aws', '~> 2.9.3'
 depends 'ohai', '~> 2.1.0'
 depends 'build-essential', '~> 1.4'
+depends 'postgresql', '= 3.4.16'
 
 recipe 'rs-mysql::default', 'Sets up a standalone MySQL server'
 recipe 'rs-mysql::collectd', 'Sets up collectd monitoring for MySQL server'
@@ -279,3 +280,10 @@ attribute 'rs-mysql/import/dump_file',
     ' Example: dumpfile_20140102.gz',
   :required => 'optional',
   :recipes => ['rs-mysql::dump_import']
+
+attribute 'rs-mysql/startup-timeout',
+  :display_name => 'MySQL Server Startup Timeout',
+  :description => 'MySQL Server Startup Timeout',
+  :required => 'optional',
+  :default => 300,
+  :recipes => [ 'rs-mysql::default' ]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -128,6 +128,17 @@ include_recipe 'rightscale_tag::default'
 include_recipe 'rightscale_volume::default'
 include_recipe 'rightscale_backup::default'
 
+ruby_block 'wait for listening' do
+  block do
+    mysql_connection_info = {
+      :host => 'localhost',
+      :username => 'root',
+      :password => node['rs-mysql']['server_root_password']
+    }
+    RsMysql::Helper.verify_mysqld_is_up(mysql_connection_info, node['rs-mysql']['startup-timeout'])
+  end
+end
+
 # Setup database tags on the server.
 # See https://github.com/rightscale-cookbooks/rightscale_tag#database-servers for more information about the
 # `rightscale_tag_database` resource.


### PR DESCRIPTION
- Because snapshots come from a running mysql server (with tables locked and filesytem frozen) an innodb integrity check must be run because it discovers "InnoDB: Database was not shut down normally!".
  This can take a long time to complete and while the mysqld service is running you cannot yet connect to the DB to run other commands such as "GRANT".
- Add error log (which shows this integrity check output).
- Add Postgres version pin because newer versions require a very recent openssl version which conflicts with mysql cookbook's version.